### PR TITLE
added time_optimize parameter to GetCartesianPath.srv for optional time optimization

### DIFF
--- a/srv/GetCartesianPath.srv
+++ b/srv/GetCartesianPath.srv
@@ -43,6 +43,9 @@ bool avoid_collisions
 # Specify additional constraints to be met by the Cartesian path
 Constraints path_constraints
 
+# Set to false if you want to disable time optimization of the trajectory, specifically helpful if you have other shapes than linear moves and want to keep the original shape.
+bool time_optimize
+
 ---
 
 # The state at which the computed path starts


### PR DESCRIPTION
This modification is essential to enable the option to disable time optimization during Cartesian Path planning.

This capability is particularly important for applications involving nonlinear Cartesian paths with multiple waypoints and turns.